### PR TITLE
Add fake OAuth2 token endpoint for Grafana integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ internal/
   promql/adapter.go              Bridges Store → Prometheus storage.Queryable
   promql/handler.go              Prometheus HTTP API handlers
   admin/                         Admin API (POST /admin/reset, GET /admin/state)
+  token/                         Fake OAuth2 token endpoint (POST /token)
   integration/                   Full-stack integration tests
 gen/google/monitoring/v3/        Generated protobuf/gRPC/gateway code (do not edit)
 proto/                           buf generation config
@@ -35,7 +36,7 @@ proto/                           buf generation config
 
 ## Architecture
 
-- **Single port, multiplexed**: cmux dispatches gRPC (HTTP/2 `content-type: application/grpc`) to the gRPC server; everything else goes to an HTTP mux serving REST, Prometheus, and admin routes.
+- **Single port, multiplexed**: cmux dispatches gRPC (HTTP/2 `content-type: application/grpc`) to the gRPC server; everything else goes to an HTTP mux serving REST, Prometheus, admin, and token routes.
 - **In-process grpc-gateway**: REST endpoints are transcoded in-process via `HandlerServer` (no loopback dial).
 - **Store interface** (`internal/store/store.go`): All services receive a `store.Store` via constructor injection. The only implementation is `MemoryStore`.
 - **Thread safety**: `MemoryStore` uses `sync.RWMutex`. All proto messages are deep-cloned via `proto.Clone` on read and write.
@@ -56,3 +57,4 @@ proto/                           buf generation config
 - Pagination uses base64-encoded offset tokens.
 - Validation returns proper gRPC status codes (`InvalidArgument`, `NotFound`, `AlreadyExists`).
 - Generated code lives in `gen/` — regenerate with `make generate`, do not edit by hand.
+- **Keep AGENTS.md up to date**: When adding new packages, endpoints, or changing architecture, update this file as part of the same change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read AGENTS.md before starting any task.

--- a/cmd/emulator/main.go
+++ b/cmd/emulator/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ata-marzban/cloud-monitoring-emulator/internal/promql"
 	"github.com/ata-marzban/cloud-monitoring-emulator/internal/server"
 	"github.com/ata-marzban/cloud-monitoring-emulator/internal/store"
+	"github.com/ata-marzban/cloud-monitoring-emulator/internal/token"
 )
 
 func main() {
@@ -56,6 +57,7 @@ func main() {
 	httpMux.Handle("/v3/", gwMux)
 	httpMux.Handle("/v1/", promql.NewHandler(s))
 	httpMux.Handle("/admin/", admin.NewHandler(s))
+	httpMux.Handle("/token", token.NewHandler())
 
 	// Create listener.
 	addr := fmt.Sprintf(":%d", *port)
@@ -88,6 +90,7 @@ func main() {
 		"rest", fmt.Sprintf("http://localhost:%d/v3/", *port),
 		"promql", fmt.Sprintf("http://localhost:%d/v1/projects/{project}/location/global/prometheus/api/v1/", *port),
 		"admin", fmt.Sprintf("http://localhost:%d/admin/", *port),
+		"token", fmt.Sprintf("http://localhost:%d/token", *port),
 	)
 
 	// Graceful shutdown on SIGINT/SIGTERM.

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -1,0 +1,38 @@
+package token
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NewHandler returns an HTTP handler for the fake OAuth2 token endpoint.
+func NewHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /token", handleToken)
+	return mux
+}
+
+func handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	if grantType != "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "unsupported_grant_type",
+			"error_description": "Only urn:ietf:params:oauth:grant-type:jwt-bearer is supported",
+		})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": "emulator-fake-token",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `POST /token` endpoint that accepts OAuth2 JWT bearer token exchange requests and returns a static fake access token
- Enables Grafana's Cloud Monitoring plugin to authenticate against the emulator by pointing `token_uri` in a fake service account JSON at the emulator
- Returns `{"access_token": "emulator-fake-token", "token_type": "Bearer", "expires_in": 3600}` for valid requests; rejects unsupported grant types with a `400` and `unsupported_grant_type` error

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)